### PR TITLE
Make r.Status an alias for r.Error

### DIFF
--- a/render.go
+++ b/render.go
@@ -65,6 +65,8 @@ type Render interface {
 	Data(status int, v []byte)
 	// Error is a convenience function that writes an http status to the http.ResponseWriter.
 	Error(status int)
+	// Status is an alias for Error (writes an http status to the http.ResponseWriter)
+	Status(status int)
 	// Redirect is a convienience function that sends an HTTP redirect. If status is omitted, uses 302 (Found)
 	Redirect(location string, status ...int)
 	// Template returns the internal *template.Template used to render the HTML
@@ -257,6 +259,10 @@ func (r *renderer) Data(status int, v []byte) {
 
 // Error writes the given HTTP status to the current ResponseWriter
 func (r *renderer) Error(status int) {
+	r.WriteHeader(status)
+}
+
+func (r *renderer) Status(status int) {
 	r.WriteHeader(status)
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -278,6 +278,13 @@ func Test_Render_BinaryData_CustomMimeType(t *testing.T) {
 	expect(t, res.Body.String(), "..jpeg data..")
 }
 
+func Test_Render_Status204(t *testing.T) {
+	res := httptest.NewRecorder()
+	r := renderer{res, nil, nil, Options{}, ""}
+	r.Status(204)
+	expect(t, res.Code, 204)
+}
+
 func Test_Render_Error404(t *testing.T) {
 	res := httptest.NewRecorder()
 	r := renderer{res, nil, nil, Options{}, ""}


### PR DESCRIPTION
An empty-body status code return is useful for more than just errors, e.g. an HTTP 204 has no body, and would be useful to call using `r.Status(204)` rather than `r.Error(204)`, since 204 isn't an error.
