### PR TITLE
Allow to use predefine compiled template from external

### DIFF
--- a/render.go
+++ b/render.go
@@ -101,7 +101,7 @@ type Options struct {
 	IndentJSON bool
 	// Allows changing of output to XHTML instead of HTML. Default is "text/html"
 	HTMLContentType string
-	// Predefine templates
+	// Allow to use predefine compiled template from external
 	Template *template.Template
 }
 


### PR DESCRIPTION
we need to use different template files from different location depends on querystring parameter.  For example, http://www.yourdomain.com/?theme=dark , we would like to maintain the template instance by our self and pass it to render middleware.  Hope it helps.

Thank you
