### PR TITLE
Adds protection against a JSON vulnerability.

### DIFF
--- a/render.go
+++ b/render.go
@@ -102,6 +102,8 @@ type Options struct {
 	Charset string
 	// Outputs human readable JSON
 	IndentJSON bool
+	// Prefixes the JSON output with the given bytes.
+	PrefixJSON []byte
 	// Allows changing of output to XHTML instead of HTML. Default is "text/html"
 	HTMLContentType string
 }
@@ -229,6 +231,9 @@ func (r *renderer) JSON(status int, v interface{}) {
 	// json rendered fine, write out the result
 	r.Header().Set(ContentType, ContentJSON+r.compiledCharset)
 	r.WriteHeader(status)
+	if len(r.opt.PrefixJSON) > 0 {
+		r.Write(r.opt.PrefixJSON)
+	}
 	r.Write(result)
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -37,6 +37,28 @@ func Test_Render_JSON(t *testing.T) {
 	expect(t, res.Body.String(), `{"one":"hello","two":"world"}`)
 }
 
+func Test_Render_JSON_Prefix(t *testing.T) {
+	m := martini.Classic()
+	prefix := ")]}',\n"
+	m.Use(Renderer(Options{
+		PrefixJSON: []byte(prefix),
+	}))
+
+	// routing
+	m.Get("/foobar", func(r Render) {
+		r.JSON(300, Greeting{"hello", "world"})
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foobar", nil)
+
+	m.ServeHTTP(res, req)
+
+	expect(t, res.Code, 300)
+	expect(t, res.Header().Get(ContentType), ContentJSON+"; charset=UTF-8")
+	expect(t, res.Body.String(), prefix + `{"one":"hello","two":"world"}`)
+}
+
 func Test_Render_Indented_JSON(t *testing.T) {
 	m := martini.Classic()
 	m.Use(Renderer(Options{


### PR DESCRIPTION
An attacker can turn a JSON endpoint's answer into a JSONP callback, by
overriding the Array constructor. Adding a prefix to a JSON response,
which makes response syntactically invalid, fixes this issue.

More information on this issue: http://haacked.com/archive/2008/11/20/anatomy-of-a-subtle-json-vulnerability.aspx
