### PR TITLE
Fix the process of retrieving an extension of a file path.

### DIFF
--- a/render.go
+++ b/render.go
@@ -33,6 +33,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-martini/martini"
 )
@@ -176,7 +177,8 @@ func compile(options Options) *template.Template {
 			return err
 		}
 
-		ext := filepath.Ext(r)
+		ext := getExt(r)
+
 		for _, extension := range options.Extensions {
 			if ext == extension {
 
@@ -203,6 +205,13 @@ func compile(options Options) *template.Template {
 	})
 
 	return t
+}
+
+func getExt(s string) string {
+	if strings.Index(s, ".") == -1 {
+		return ""
+	}
+	return "." + strings.Join(strings.Split(s, ".")[1:], ".")
 }
 
 type renderer struct {

--- a/render_test.go
+++ b/render_test.go
@@ -450,6 +450,12 @@ func Test_Render_NoRace(t *testing.T) {
 	<-done
 }
 
+func Test_GetExt(t *testing.T) {
+	expect(t, getExt("test"), "")
+	expect(t, getExt("test.tmpl"), ".tmpl")
+	expect(t, getExt("test.go.html"), ".go.html")
+}
+
 /* Test Helpers */
 func expect(t *testing.T, a interface{}, b interface{}) {
 	if a != b {


### PR DESCRIPTION
Add a function which retrieves an extension of a file path because `filepath.Ext` returns the suffix beginning at the final dot in the final element of path and we can not retrieve the extension of `foo.go.html` correctly (We want to retrieve `.go.html` as the extension but `filepath.Ext` returns `.html`). #14
