### PR TITLE
Changed temporary buffers to a pooled bytes.Buffer implementation.

### DIFF
--- a/render.go
+++ b/render.go
@@ -48,6 +48,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/oxtoacart/bpool"
+
 	"github.com/go-martini/martini"
 )
 
@@ -61,6 +63,9 @@ const (
 	ContentXML     = "text/xml"
 	defaultCharset = "UTF-8"
 )
+
+// Provides a temporary buffer to execute templates into and catch errors.
+var bufpool *bpool.BufferPool
 
 // Included helper functions for use when rendering html
 var helperFuncs = template.FuncMap{
@@ -145,6 +150,7 @@ func Renderer(options ...Options) martini.Handler {
 	opt := prepareOptions(options)
 	cs := prepareCharset(opt.Charset)
 	t := compile(opt)
+	bufpool = bpool.NewBufferPool(64)
 	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {
 		var tc *template.Template
 		if martini.Env == martini.Dev {
@@ -274,7 +280,7 @@ func (r *renderer) HTML(status int, name string, binding interface{}, htmlOpt ..
 		name = opt.Layout
 	}
 
-	out, err := r.execute(name, binding)
+	buf, err := r.execute(name, binding)
 	if err != nil {
 		http.Error(r, err.Error(), http.StatusInternalServerError)
 		return
@@ -283,7 +289,8 @@ func (r *renderer) HTML(status int, name string, binding interface{}, htmlOpt ..
 	// template rendered fine, write out the result
 	r.Header().Set(ContentType, r.opt.HTMLContentType+r.compiledCharset)
 	r.WriteHeader(status)
-	io.Copy(r, out)
+	io.Copy(r, buf)
+	bufpool.Put(buf)
 }
 
 func (r *renderer) XML(status int, v interface{}) {
@@ -339,7 +346,7 @@ func (r *renderer) Template() *template.Template {
 }
 
 func (r *renderer) execute(name string, binding interface{}) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
+	buf := bufpool.Get()
 	return buf, r.t.ExecuteTemplate(buf, name, binding)
 }
 


### PR DESCRIPTION
I've changed `bytes.NewBuffer` to a pooled `bytes.Buffer` implementation.

This reduces garbage per-request and increases performance. Some local testing (across both Martini and a non-Martini application) saw a ~26% improvement in req/s (26k -> 33k) when making this change, and less allocations when profiled (reducing the calls to makeSlice). I've also tested a fixed (10K) buffer which sat in-between, but was less flexible as it heavily depends on the typical response size of the application.
- Pooled buffers reduce garbage per-request (render)
- Set default size as 64 as testing shows minimal memory impact and good
  performance (no noticeable gains above 64 buffers) - this could be exposed in `render.Options` if desired.
- Buffer returned to pool after writing rendered template to
  ResponseWriter.

(I wrote [a short article](http://elithrar.github.io/article/approximating-html-template-inheritance/) on this—scroll down to the last example for how I implemented it in my own application).
